### PR TITLE
bolt-simple-taproot: update interactive session protocol

### DIFF
--- a/bolt-simple-taproot.md
+++ b/bolt-simple-taproot.md
@@ -802,10 +802,10 @@ The sending node:
 
 The receiving node MUST fail the negotiation by sending `tx_abort` if:
 
-- the message doesn't include a `session_nonces` value.
+- the message doesn't include a `commit_nonces` value.
 
-- the interactive session is spending a previous funding transaction and
-  `session_nonces` does not include a `funding_nonce`.
+- the interactive session is spending a previous funding transaction that
+  uses taproot and `tx_complete` does not include a `funding_nonce`.
 
 `commit_nonce` and `next_commit_nonce` are verification nonces and must
 be generated using the same process as other verification nonces.
@@ -1235,7 +1235,7 @@ A new TLV stream is added to the `revoke_and_ack` message:
 2. types:
    1. type: 22 (`next_local_nonces`)
    2. data:
-       * [`local_nonces`: `local_nonces`]
+       * [`local_nonces`: `next_commit_nonces`]
 
 Similar to sending the `next_per_commitment_point`, we also send the _next_
 `musig2` nonces, after we revoke a state. Sending these nonces allows the 
@@ -1269,7 +1269,7 @@ We add 2 new TLV fields to the `channel_reestablish` message:
 2. types:
    1. type: 22 (`next_local_nonces`)
    2. data:
-      * [`next_local_nonces`: `next_local_nonces`]
+      * [`local_nonces`: `next_commit_nonces`]
    1. type: 24 (`current_commit_nonce`)
    2. data:
        * [`66*byte`:`public_nonce`]
@@ -1279,7 +1279,7 @@ value in this message, we ensure that the remote party has our public nonces,
 which are required to generate new commitment signatures.
 
 `current_commit_nonce` is used to re-send signatures for the * current * 
-commitment transaction.
+commitment transaction if a disconnection happened while signing an `interactive-tx` session.
 
 ##### Requirements
 
@@ -1290,6 +1290,7 @@ The sender:
   - if it has sent commitment_signed for an interactive transaction 
     construction but it has not received tx_signatures:
       - MUST include `current_commit_nonce` for the commitment transaction that is being built.
+      - MUST include a `next_commit_nonce` for the funding transaction that is being built.
 
 The recipient:
 

--- a/bolt-simple-taproot.md
+++ b/bolt-simple-taproot.md
@@ -563,8 +563,7 @@ Note that these TLV types exist across different messages, but their type IDs ar
 #### local_nonces
 - type: 22
 - data:
-   * [`u16`: `num_entries`]
-   * [`num_entries * nonce_entry`: `entries`]
+   * [`... * nonce_entry`: `entries`]
 
 where `nonce_entry` is:
    * [`32*byte`: `txid`]
@@ -782,19 +781,22 @@ channels to:
 
 1. `tlv_stream`: `tx_complete_tlvs`
 2. types:
-    1. type: 4 (`session_nonces`)
+    1. type: 4 (`commit_nonces`)
     2. data:
-      * [`66 or 99 * byte`:`commit_nonce` || `next_commit_nonce` || (optional) `funding_nonce`]
+      * [`2*66*byte`:`commit_nonce` || `next_commit_nonce`]
+    1. type: 6 (`funding_nonce`)
+    2. data:
+    * [`66*byte`:`funding_nonce`]
 
 ##### Requirements
 
 The sending node:
 
-- MUST include a `commit_nonce` for the commitment transaction that is being 
-  built, which can be the first commitment transaction for channel opening,
-  or a splice transaction.
-- MUST include a `next_commit_nonce` that will be used to sign the next 
-  commitment transaction, once the interactive transaction session completes. 
+- MUST include a `commit_nonces` field that contains 
+  - a `commit_nonce` for the commitment transaction that is being built i.e. for
+    the current commitment number 
+  - a `next_commit_nonce` that will be used to sign the next commitment 
+    transaction, once the interactive transaction session completes. 
 - IF the session is spending a previous funding transaction, MUST include
   a `funding_nonce` that will be used to sign it. 
 
@@ -1233,7 +1235,7 @@ A new TLV stream is added to the `revoke_and_ack` message:
 2. types:
    1. type: 22 (`next_local_nonces`)
    2. data:
-       * [`local_nonces`: `nonces_map`]
+       * [`local_nonces`: `local_nonces`]
 
 Similar to sending the `next_per_commitment_point`, we also send the _next_
 `musig2` nonces, after we revoke a state. Sending these nonces allows the 
@@ -1264,10 +1266,10 @@ The recipient:
 We add 2 new TLV fields to the `channel_reestablish` message:
 
 1. `tlv_stream`: `channel_reestablish_tlvs`
-2. types:      * [`66*byte`: `public_nonce`]
+2. types:
    1. type: 22 (`next_local_nonces`)
    2. data:
-      * [`next_local_nonces`: `nonces_map`]
+      * [`next_local_nonces`: `next_local_nonces`]
    1. type: 24 (`current_commit_nonce`)
    2. data:
        * [`66*byte`:`public_nonce`]

--- a/bolt-simple-taproot.md
+++ b/bolt-simple-taproot.md
@@ -376,6 +376,8 @@ reproduced:
      `musig2.NonceGen` algorithm with the required values, and the `rand'`
      value set to `k_i`.
 
+  4. Use the id of the commitment's funding transaction as extra input, as
+     described in `musig2.NonceGen`.
 
 #### Nonce Handling
 
@@ -582,6 +584,12 @@ TLV type that houses the `musig2` public nonces.
 
 We add `option_simple_taproot` to the set of defined channel types.
 
+Since the id of the funding transaction is not known yet when nodes exchange
+`open_channel` and `accept_channel`, a dummy funding txid of 32 zero-byte
+must be used instead as extra input to the nonce generation algorithm to 
+generate the verification nonce for the first commitment. This only applies to
+the v1 channel establishment protocol.
+
 #### `open_channel` Extensions
 
 1. `tlv_stream`: `open_channel_tlvs`
@@ -783,10 +791,11 @@ channels to:
 2. types:
     1. type: 4 (`commit_nonces`)
     2. data:
-      * [`2*66*byte`:`commit_nonce` || `next_commit_nonce`]
+      * [`66*byte`:`commit_nonce`]
+      * [`66*byte`:`next_commit_nonce`]
     1. type: 6 (`funding_nonce`)
     2. data:
-    * [`66*byte`:`funding_nonce`]
+      * [`66*byte`:`funding_nonce`]
 
 ##### Requirements
 

--- a/bolt-simple-taproot.md
+++ b/bolt-simple-taproot.md
@@ -570,7 +570,7 @@ where `nonce_entry` is:
    * [`32*byte`: `txid`]
    * [`66*byte`: `public_nonce`]
 
-### Channel Funding
+### Channel Establishment v1
 
 `n_a_L`: Alice's local secret nonce
 
@@ -765,6 +765,74 @@ The recipient:
 
 - MUST fail the channel if `next_local_nonce` is absent.
 
+### Interactive Transaction Construction  
+
+The interactive transaction construction protocol is extended to support the 
+exchange of nonces and partial signatures:
+- nonces are added to `tx_complete`
+- partial signatures are added to `tx_signatures`
+
+Updating the interactive transaction protocol adds support for simple taproot
+channels to:
+- the channel v2 establishment protocol
+- splicing
+- funding transaction fee bumping
+
+#### `tx_complete` Extensions
+
+1. `tlv_stream`: `tx_complete_tlvs`
+2. types:
+    1. type: 4 (`session_nonces`)
+    2. data:
+      * [`66 or 99 * byte`:`commit_nonce` || `next_commit_nonce` || (optional) `funding_nonce`]
+
+##### Requirements
+
+The sending node:
+
+- MUST include a `commit_nonce` for the commitment transaction that is being 
+  built, which can be the first commitment transaction for channel opening,
+  or a splice transaction.
+- MUST include a `next_commit_nonce` that will be used to sign the next 
+  commitment transaction, once the interactive transaction session completes. 
+- IF the session is spending a previous funding transaction, MUST include
+  a `funding_nonce` that will be used to sign it. 
+
+The receiving node MUST fail the negotiation by sending `tx_abort` if:
+
+- the message doesn't include a `session_nonces` value.
+
+- the interactive session is spending a previous funding transaction and
+  `session_nonces` does not include a `funding_nonce`.
+
+`commit_nonce` and `next_commit_nonce` are verification nonces and must
+be generated using the same process as other verification nonces.
+
+`funding_nonce` is local to the interactive tx session and should be 
+randomly generated.
+
+#### `tx_signature` Extensions
+
+1. `tlv_stream`: `tx_signature_tlvs`
+2. types:
+    1. type: 2 (`partial_shared_input_signature`)
+    2. data:
+        * [`98*byte`: `partial_signature || public_nonce`]
+
+##### Requirements
+
+The sending node:
+
+- IF the session is spending a previous funding transaction, MUST include a 
+  `partial_shared_input_signature` for the shared input, generated with local
+  and remote funding nonces exchanged in `tx_complete`.
+
+The receiving node MUST fail the negotiation by sending `tx_abort` if:
+
+- the interactive session is spending a previous funding transaction and 
+  `partial_shared_input_signature` is missing.
+
+
 ### Cooperative Closure
 
 Compared to the base segwit v0 channel type, for simple taproot channels, the
@@ -794,7 +862,7 @@ For taproot channels, the shutdown message includes a single nonce:
 2. types:
     1. type: 8 (`shutdown_nonce`)
     2. data:
-        * [`66*byte`:`nonces`]
+        * [`66*byte`:`public_nonce`]
 
 The `shutdown_nonce` represents the sender's "closee nonce" - the nonce they
 will use when sending `closing_sig` messages. This applies to both the legacy
@@ -1163,105 +1231,89 @@ A new TLV stream is added to the `revoke_and_ack` message:
 
 1. `tlv_stream`: `revoke_and_ack_tlvs`
 2. types:
-   1. type: 4 (`next_local_nonce`)
+   1. type: 22 (`next_local_nonces`)
    2. data:
-      * [`66*byte`: `public_nonce`]
+       * [`local_nonces`: `nonces_map`]
 
 Similar to sending the `next_per_commitment_point`, we also send the _next_
-`musig2` nonces, after we revoke a state. Sending this nonce allows the remote
-party to propose another state transition as soon as the message is received.
+`musig2` nonces, after we revoke a state. Sending these nonces allows the 
+remote party to propose another state transition as soon as the message is 
+received.
 
 ##### Requirements
 
 The sender:
 
-- MUST use the `musig2.NonceGen` algorithm to generate a unique nonce to send
-  in the `next_local_nonce` field.
+- MUST use the `musig2.NonceGen` algorithm to generate unique nonces to send
+  in the `next_local_nonces` field.
+- MUST include a funding_txid and nonce for each valid commitment transaction.
+- If the local nonce generation is non-deterministic and the recipient co-signs
+  commitments only upon pending broadcast:
+    - MUST **securely** store local nonces.
 
 The recipient:
 
-- MUST fail the channel if `next_local_nonce` is absent.
-
-- If the local nonce generation is non-deterministic and the recipient co-signs
-  commitments only upon pending broadcast:
-
-  - MUST **securely** store the local nonce.
+- MUST fail the channel if `next_local_nonces` is absent or cannot be parsed.
+- MUST fail the channel if an active commitment funding txid is missing in 
+  `next_local_nonces`.
 
 ### Message Retransmission
 
 #### `channel_reestablish` Extensions
 
-We add a new TLV field to the `channel_reestablish` message:
+We add 2 new TLV fields to the `channel_reestablish` message:
 
 1. `tlv_stream`: `channel_reestablish_tlvs`
-2. types:
-   1. type: 4 (`next_local_nonce`)
+2. types:      * [`66*byte`: `public_nonce`]
+   1. type: 22 (`next_local_nonces`)
    2. data:
-      * [`66*byte`: `public_nonce`]
-   3. type: 22 (`local_nonces`)
-   4. data:
-      * [`local_nonces`: `nonces_map`]
+      * [`next_local_nonces`: `nonces_map`]
+   1. type: 24 (`current_commit_nonce`)
+   2. data:
+       * [`66*byte`:`public_nonce`]
 
-Similar to the `next_per_commitment_point`, by sending the `next_local_nonce`
-value in this message, we ensure that the remote party has our public nonce,
-which is required to generate a new commitment signature.
+Similar to the `next_per_commitment_point`, by sending the `next_local_nonces`
+value in this message, we ensure that the remote party has our public nonces,
+which are required to generate new commitment signatures.
+
+`current_commit_nonce` is used to re-send signatures for the * current * 
+commitment transaction.
 
 ##### Requirements
 
 The sender:
 
-- MUST set `next_local_nonce` to a fresh, unique `musig2` nonce as specified by
-  `bip-musig2`
-- For taproot channels, SHOULD also populate the `local_nonces` field:
-  - MUST include at least one entry with an empty hash (32 zero bytes) as the key,
-    containing the primary commitment nonce
-  - The value for the empty hash key MUST match the value in `next_local_nonce`
-  - MAY include additional entries for in-progress splice transactions
-  - MUST sort entries by TXID in lexicographical order when encoding
+  - MUST include one entry for each active commitment transaction,
+    indexed by the commitment transaction's funding txid.
+  - if it has sent commitment_signed for an interactive transaction 
+    construction but it has not received tx_signatures:
+      - MUST include `current_commit_nonce` for the commitment transaction that is being built.
 
 The recipient:
 
-- MUST fail the channel if `next_local_nonce` is absent, or cannot be parsed as
-  two compressed secp256k1 points.
-- When `local_nonces` field is present:
-  - MUST prioritize `local_nonces` over `next_local_nonce` for obtaining the
-    commitment nonce
-  - MUST use the nonce associated with the empty hash key (32 zero bytes) as the
-    primary commitment nonce
-  - MAY store additional nonces for splice coordination
-- For taproot channels, if neither `next_local_nonce` nor `local_nonces` contains
-  a valid nonce, MUST fail the channel
+- MUST fail the channel if `next_local_nonces` is absent, or cannot be parsed.
+- MUST fail the channel if an active commitment funding txid is missing in
+  `next_local_nonces`.
+- if `channel_reestablish` includes a `next_funding_txid` which matches the
+  latest interactive funding transaction or the current channel funding transaction
+  - if it must re-transmit its `commitment_signed`
+    - if `current_commit_nonce` is missing: MUST fail the channel
 
-A node:
-
-  - If ALL of the following conditions apply:
-  
-    - It has previously sent a `commitment_signed` message
-  
-    - It never processed the corresponding `revoke_and_ack` message
-  
-    - It decides to retransmit the exact `update_` messages from the last sent
-      `commitment_signed`
-  
-  - THEN it must regenerate the partial signature using the newly received
-    `next_local_nonce`
 
 ### Splice Coordination
 
 Splicing allows parties to modify the funding output of an existing channel without
 closing it. During splice operations, multiple commitment transactions may exist
-concurrently, each requiring its own MuSig2 nonce coordination. The `local_nonces`
-field enables this coordination by mapping transaction IDs to their respective nonces.
+concurrently, each requiring its own MuSig2 nonce coordination. The `next_local_nonces`
+field enables this coordination by mapping funding transaction ids to their 
+respective nonce.
 
 #### Splice Nonce Management
 
 During splice negotiation:
 
-- Each splice transaction MUST have a unique TXID as the key in the `local_nonces` map
-- The primary (non-splice) commitment transaction MUST use an empty hash (32 zero
-  bytes) as its key
-- Parties MUST include nonces for all active splice transactions in their
-  `local_nonces` map
+- Parties MUST include nonces for all active commitment transactions in their
+  `next_local_nonces` map, indexed by their funding tx id.
 - Completed or abandoned splices SHOULD have their nonces removed from the map in
   subsequent messages
 
@@ -1269,12 +1321,11 @@ During splice negotiation:
 
 When a splice is initiated:
 
-- The initiating party MUST generate a fresh nonce for the splice transaction
-- Both parties MUST add the splice TXID and corresponding nonce to their
-  `local_nonces` map
-- The nonce MUST be communicated in the next `commitment_signed` or
-  `channel_reestablish` message
-
+- nonces are added to `tx_complete`, including a specific, random 
+  `funding_nonce` used to spend the previous funding transaction.
+- nonces for each active commitment transaction are added to `revoke_and_ack`
+  and `channel_reestablish`.
+- 
 When a splice is completed:
 
 - Parties SHOULD remove the splice TXID from their `local_nonces` map
@@ -1282,18 +1333,15 @@ When a splice is completed:
 
 When multiple splices are pending:
 
-- Each splice MUST have a distinct TXID and nonce pair
-- Nonces MUST NOT be reused across different splice transactions
-- The `local_nonces` map MAY contain multiple entries during concurrent splice
-  operations
+- Each splice is identified by its funding transaction id. It is highly 
+  recommended to use the funding transaction id as an additional input to the
+  verification nonce generation algorithm. 
 
 ##### Backward Compatibility
 
-Nodes that do not support splicing:
+Nodes that do not support splicing will simply use a nonce map with a single
+entry indexed by the commitment transaction's funding tx id.
 
-- Will ignore the `local_nonces` field (due to its even TLV type number)
-- Can continue to use the single `next_local_nonce` field
-- Will not be able to participate in splice operations
 
 ### Funding Transactions
 


### PR DESCRIPTION
Add extensions to the interactive transaction protocol, which is used for dual-funding, splicing and funding transaction fee bumping.

Includes a few changes to the current simple taproot channels proposal:
- drop support for single "next local nonce" in revoke_and_ack in favour of the funding txid -> nonce map, even for nodes that do not support dual-funding (there will just be a single entry then).
- the nonce map is always indexed by funding tx id, even for the current commitment transaction (instead of 32 zero bytes)