### PR TITLE
Updates to simple taproot channels for cross-compatibility

### DIFF
--- a/bolt-simple-taproot.md
+++ b/bolt-simple-taproot.md
@@ -534,7 +534,6 @@ feature bit would not be able to open publicly advertised channels.
 Throughout this document, we assume that `option_simple_taproot` was
 negotiated, and also the `option_simple_taproot` channel type is used.
 
-
 ### New TLV Types
 
 Note that these TLV types exist across different messages, but their type IDs are always the same.
@@ -560,13 +559,13 @@ Note that these TLV types exist across different messages, but their type IDs ar
 - data:
    * [`66*byte`: `public_nonce`]
 
-#### local_nonces
+#### next_local_nonces
 - type: 22
 - data:
-   * [`... * nonce_entry`: `entries`]
+   * [`...*nonce_entry`: `entries`]
 
 where `nonce_entry` is:
-   * [`32*byte`: `txid`]
+   * [`32*byte`: `funding_txid`]
    * [`66*byte`: `public_nonce`]
 
 ### Channel Funding
@@ -602,7 +601,6 @@ The sending node:
 The receiving node MUST fail the channel if:
 
   - the message doesn't include a `next_local_nonce` value.
-
   - the specified public nonce cannot be parsed as two compressed secp256k1
     points
 
@@ -1162,28 +1160,30 @@ A new TLV stream is added to the `revoke_and_ack` message:
 
 1. `tlv_stream`: `revoke_and_ack_tlvs`
 2. types:
-   1. type: 4 (`next_local_nonce`)
+   1. type: 22 (`next_local_nonces`)
    2. data:
-      * [`66*byte`: `public_nonce`]
+      * [`...*nonce_entry`: `nonces`]
 
 Similar to sending the `next_per_commitment_point`, we also send the _next_
-`musig2` nonces, after we revoke a state. Sending this nonce allows the remote
+`musig2` nonces, after we revoke a state. Sending these nonces allows the remote
 party to propose another state transition as soon as the message is received.
 
 ##### Requirements
 
 The sender:
 
-- MUST use the `musig2.NonceGen` algorithm to generate a unique nonce to send
-  in the `next_local_nonce` field.
+- MUST use the `musig2.NonceGen` algorithm to generate unique nonces to send
+  in the `next_local_nonces` field.
+- MUST include one entry for each active commitment transaction, indexed by the
+  commitment transaction's `funding_txid`.
 
 The recipient:
 
-- MUST fail the channel if `next_local_nonce` is absent.
-
+- MUST fail the channel if `next_local_nonces` is absent.
+- MUST fail the channel if an active commitment's `funding_txid` is missing in
+  `next_local_nonces`.
 - If the local nonce generation is non-deterministic and the recipient co-signs
   commitments only upon pending broadcast:
-
   - MUST **securely** store the local nonce.
 
 ### Message Retransmission
@@ -1194,41 +1194,28 @@ We add a new TLV field to the `channel_reestablish` message:
 
 1. `tlv_stream`: `channel_reestablish_tlvs`
 2. types:
-   1. type: 4 (`next_local_nonce`)
+   1. type: 22 (`next_local_nonces`)
    2. data:
-      * [`66*byte`: `public_nonce`]
-   3. type: 22 (`local_nonces`)
-   4. data:
-      * [`local_nonces`: `nonces_map`]
+      * [`...*nonce_entry`: `nonces`]
 
-Similar to the `next_per_commitment_point`, by sending the `next_local_nonce`
-value in this message, we ensure that the remote party has our public nonce,
-which is required to generate a new commitment signature.
+Similar to the `next_per_commitment_point`, by sending the `next_local_nonces`
+value in this message, we ensure that the remote party has our public nonces,
+which are required to generate new commitment signatures.
 
 ##### Requirements
 
 The sender:
 
-- MUST set `next_local_nonce` to a fresh, unique `musig2` nonce as specified by
-  `bip-musig2`
-- For taproot channels, SHOULD also populate the `local_nonces` field:
-  - MUST include one entry for each active commitment transaction,
-    indexed by the commitment transaction's funding txid.
-  - MAY include additional entries for in-progress splice transactions
-  - MUST sort entries by TXID in lexicographical order when encoding
+- MUST set `next_local_nonces` to fresh, unique `musig2` nonces as specified by
+  `bip-musig2`.
+- MUST include one entry for each active commitment transaction, indexed by the
+  commitment transaction's `funding_txid`.
 
 The recipient:
 
-- MUST fail the channel if `next_local_nonce` is absent, or cannot be parsed as
-  two compressed secp256k1 points.
-- When `local_nonces` field is present:
-  - MUST prioritize `local_nonces` over `next_local_nonce` for obtaining the
-    commitment nonce
-  - MUST fail the channel if an active commitment funding txid is missing in
-    `next_local_nonces`.
-  - MAY store additional nonces for splice coordination
-- For taproot channels, if neither `next_local_nonce` nor `local_nonces` contains
-  a valid nonce, MUST fail the channel
+- MUST fail the channel if `next_local_nonces` is absent, or cannot be parsed.
+- MUST fail the channel if an active commitment's `funding_txid` is missing in
+  `next_local_nonces`.
 
 A node:
 
@@ -1242,26 +1229,24 @@ A node:
       `commitment_signed`
   
   - THEN it must regenerate the partial signature using the newly received
-    `next_local_nonce`
+    `next_local_nonces`
 
 ### Splice Coordination
 
 Splicing allows parties to modify the funding output of an existing channel
 without closing it. During splice operations, multiple commitment transactions
 may exist concurrently, each requiring its own MuSig2 nonce coordination. The
-`local_nonces` field enables this coordination by mapping transaction IDs to
-their respective nonces.
+`next_local_nonces` field enables this coordination by mapping transaction IDs
+to their respective nonces.
 
 #### Splice Nonce Management
 
 During splice negotiation:
 
 - Each splice transaction MUST have a unique TXID as the key in the
-`local_nonces` map
+  `next_local_nonces` map
 - Parties MUST include nonces for all active commitment transactions in their
-  `next_local_nonces` map, indexed by their funding tx id.
-- Completed or abandoned splices SHOULD have their nonces removed from the map in
-  subsequent messages
+  `next_local_nonces` map, indexed by their `funding_txid`
 
 ##### Requirements for Splice Coordination
 
@@ -1269,26 +1254,21 @@ When a splice is initiated:
 
 - The initiating party MUST generate a fresh nonce for the splice transaction
 - Both parties MUST add the splice TXID and corresponding nonce to their
-  `local_nonces` map
-- The nonce MUST be communicated in the next `commitment_signed` or
+  `next_local_nonces` map
+- The nonce MUST be communicated in the next `revoke_and_ack` or
   `channel_reestablish` message
-
-When a splice is completed:
-
-- Parties SHOULD remove the splice TXID from their `local_nonces` map
-- The primary commitment nonce SHOULD be updated to reflect the new funding output
 
 When multiple splices are pending:
 
 - Each splice MUST have a distinct TXID and nonce pair
 - Nonces MUST NOT be reused across different splice transactions
-- The `local_nonces` map MAY contain multiple entries during concurrent splice
-  operations
+- The `next_local_nonces` map MUST contain multiple entries during concurrent
+  splice operations
 
 ##### Backward Compatibility
 
 Nodes that do not support splicing will simply use a nonce map with a single
-entry indexed by the commitment transaction's funding tx id.
+entry indexed by the commitment transaction's `funding_txid`.
 
 ### Funding Transactions
 

--- a/bolt-simple-taproot.md
+++ b/bolt-simple-taproot.md
@@ -340,7 +340,7 @@ In this scenario are nonce generated via a counter is deemed to be safe as:
 
   2. Each commitment state has a unique number which is currently encoded as a
      48-bit integer across the sequence and lock time of the commitment
-     transaction. 
+     transaction.
 
   3. The shachain scheme is used today to generate a fresh nonce-like value for
      the revocation scheme of today's penalty based channels.
@@ -367,15 +367,15 @@ reproduced:
   2. Derive a _new_ shachain root to be used to generate `musig2` secret nonces
      via a `HMAC` invocation as: `musig2_shachain_root = hmac(msg,
      shachain_root_hash)`, where `msg` is any string that can serve to uniquely
-     bind the produced secret to this dedicated context. A recommend value is
-     the ASCII string `taproot-rev-root`.
+     bind the produced secret to this dedicated context. A recommended value is
+     the ASCII string `taproot-rev-root` concatenated with the `funding_txid`
+     (which allows deriving distinct deterministic shachains when splicing).
 
   3. Given a commitment height/number (`N`), the verification nonce to send to
      the remote party party can be derived by obtaining the `Nth` shachain leaf
      preimage `k_i`. The verification nonce to be derived by calling the
      `musig2.NonceGen` algorithm with the required values, and the `rand'`
      value set to `k_i`.
-
 
 #### Nonce Handling
 


### PR DESCRIPTION
This PR contains 4 independent commits on top of https://github.com/lightning/bolts/pull/995, to align the spec with the splicing-compatible implementation made in `eclair`, which should be straightforward to update in `lnd`. It is best reviewed commit-by-commit, where each commit message details the rationale for each commit.

The first commit contains the TLV changes that would make `lnd` and `eclair` compatible: it just uses `next_local_nonces` instead of `next_local_nonce` in `channel_reestablish` and `revoke_and_ack`. Note that we remove the `next_local_nonce` TLV from these messages: `lnd` should keep including it for its currently deployed staging taproot channels for backwards-compat, but it MUST NOT be in the final BOLT nor be included when using the final, official taproot feature bit (otherwise we're including redundant data and making messages potentially inconsistent for no good reason).

The second commit simply adds the `funding_txid` to the recommended shachain extension for deterministic nonce derivation, which ensures that it can be used unchanged when adding support for splicing.

The third commit fixes the specification for `option_simple_close` extensions, which was incorrect in several places regarding which closee nonces must be used.

The last commit makes `option_simple_close` an explicit dependency of the final taproot feature bit, since it was explicitly designed for that, and removes extensions used only for the staging version that `lnd` uses (which won't be implemented by anyone else).